### PR TITLE
handling the case of multiple top-level headers

### DIFF
--- a/pandas_sphinx_theme/docs-toc.html
+++ b/pandas_sphinx_theme/docs-toc.html
@@ -1,7 +1,7 @@
 {% set page_toc = get_page_toc_object() %}
 
 {% include "edit_this_page.html" %}
-{%- if page_toc.children | length > 1 %}
+{%- if page_toc.children | length > 0 %}
 <div class="tocsection onthispage"><i class="fas fa-list"></i> On this page</div>
 {% endif -%}
 <nav id="bd-toc-nav">


### PR DESCRIPTION
I ran into a weird bug - if you have a page with **multiple top-level headers**, then the in-page TOC logic breaks down.

This is less-common (though possible) with rST, but consider in markdown a page like this:

```
My title
========

# My header 1

Content 1

# My header 2

Content 2
```

In this case, Sphinx will parse *all* of the headers at the same, top level. Our in-page TOC code assumes that the *only* top-level header is the title node, and that all other headers are underneath it.

This PR does the following:

* Check if there is more than 1 entry in the TOC object. If so, it means there is more than 1 header at the top level.
* Assume that the non-title top-level headers are the "true" headers for the document
* In the Jinja step, take the non-title top-level headers, and append them to the title's top-level header, so that we can render

The one awkward thing is that if there are *other* 2nd and 3rd level headers in-between the next 1st-level header, they will be missed in the TOC. Something like this:


```
My title
========

## My second level

# My header 1

Content 1

# My header 2

Content 2
```

The TOC would only show "My header 1" and "My header 2".

But I think that's *probably* the behavior we'd want to encourage?

Lemme know if you'd like me to explain a bit more...I think the longer-term solution will be to make the "get_page_toc" function a little bit less-hacky, but this seems like a reasonable patch for now