### PR TITLE
Fix admonition special case (custom named admonition)

### DIFF
--- a/docs/demo/demo.rst
+++ b/docs/demo/demo.rst
@@ -417,6 +417,16 @@ Admonitions
 
    You can make up your own admonition too.
 
+.. admonition:: If you add a name flag, it will be styled
+   :name: warning
+
+   For example, this admonition block uses the following code:
+
+   .. code-block::
+
+      .. admonition:: If you add a name flag, it will be styled
+         :name: warning
+
 Topics, Sidebars, and Rubrics
 -----------------------------
 


### PR DESCRIPTION
This adds a special case to the "notes/warn/etc" admonition handling.

Admonitions are different because users can specify their own titles. This PR:

* Uses the "note" admonition class by default
* Updates the `admonitiontitles` dictionary on-the-fly to make it use the user-provided title
* Then makes the admonition behave like any other admonition

This also makes it possible to *style* the admonition output using the `:name:` flag, so you can do things like

```
.. admonition: my title
   :name: warning

   A warning-styled admonition
```

See the end of the admonitions section here: https://176-130237506-gh.circle-artifacts.com/0/html/demo/demo.html#admonitions

For comparison, note the admonition at the end in the docs is *not* styled:
https://pandas-sphinx-theme.readthedocs.io/en/latest/demo/demo.html#admonitions



closes #117 and #70 