### PR TITLE
Automatically expand content to fill remaining space

### DIFF
--- a/pandas_sphinx_theme/layout.html
+++ b/pandas_sphinx_theme/layout.html
@@ -61,7 +61,7 @@
           {% endblock %}
 
           {% block docs_main %}
-          <main class="col-12 col-md-9 col-xl-8 py-md-3 pl-md-5 bd-content" role="main">
+          <main class="col py-md-3 pl-md-5 bd-content overflow-auto" role="main">
               {% block docs_body %}
               <div>
                 {% block body %} {% endblock %}


### PR DESCRIPTION
This PR removes all of the explicit `col` widths of the "main" content section, and replaces them with a single `col` class, which bootstrap will use to expand to take up whatever remaining space exists on the page. I think this simplifies how things work a bit, and we get the bonus of not worrying that the main content isn't filling up the space available to it.

It also adds an `overflow` class to make sure that content is properly wrapped