### PR TITLE
Read version from __init__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,32 @@
 """Sphinx Bootstrap Theme package."""
+import codecs
+import os
+import re
+
 from setuptools import setup
+
+
+# from https://packaging.python.org/guides/single-sourcing-package-version/
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def read(*parts):
+    with codecs.open(os.path.join(HERE, *parts), 'r') as fp:
+        return fp.read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
 
 
 setup(
     name="pydata-sphinx-theme",
-    version="0.0.1.dev0",
+    version=find_version("pydata-sphinx-theme", "__init__.py"),
     description="Sphinx Bootstrap Theme - pydata version.",
     url="https://github.com/pandas-dev/pydata-sphinx-theme",
     #

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def find_version(*file_paths):
 
 setup(
     name="pydata-sphinx-theme",
-    version=find_version("pydata-sphinx-theme", "__init__.py"),
+    version=find_version("pydata_sphinx_theme", "__init__.py"),
     description="Sphinx Bootstrap Theme - pydata version.",
     url="https://github.com/pandas-dev/pydata-sphinx-theme",
     #


### PR DESCRIPTION
@choldgraf the old school way it is. I actually just took the code from the packaging guide (https://packaging.python.org/guides/single-sourcing-package-version/), indeed much lighter weight than some tool.