### PR TITLE
Fixing TOC for single-header page

### DIFF
--- a/pydata_sphinx_theme/docs-toc.html
+++ b/pydata_sphinx_theme/docs-toc.html
@@ -1,9 +1,8 @@
 {% set page_toc = get_page_toc_object() %}
 
 {% include "edit_this_page.html" %}
-{%- if page_toc.children | length > 1 %}
+{%- if page_toc.children | length > 0 %}
 <div class="tocsection onthispage"><i class="fas fa-list"></i> On this page</div>
-{% endif -%}
 <nav id="bd-toc-nav">
     <ul class="nav section-nav flex-column">
     {% for item in page_toc.children recursive %}
@@ -18,3 +17,4 @@
     {% endfor %}
     </ul>
 </nav>
+{% endif -%}


### PR DESCRIPTION
Pages with only one header trigger a bug where the "On this page" text doesn't show up, but the header it self *does* show up. This changes the template so that the TOC is *only* injected if there's at least one header

An example of this in action is the changelog page: https://pydata-sphinx-theme.readthedocs.io/en/latest/changelog.html, which has a header, and this shows up in the right TOC, but the "On this page" wording does not.

cc @jorisvandenbossche who I think won't find this controversial either :-)