### PR TITLE
Include other css after our css

### DIFF
--- a/pydata_sphinx_theme/layout.html
+++ b/pydata_sphinx_theme/layout.html
@@ -13,9 +13,8 @@
 
 {%- block css %}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.min.css" integrity="sha384-KA6wR/X5RY4zFAHpv/CnoG2UW1uogYfdnP67Uv7eULvTveboZJg0qUpmJZb5VqzN" crossorigin="anonymous">
-
-    {{- css() }}
     <link href="{{ pathto('_static/css/index.css', 1) }}" rel="stylesheet">
+    {{- css() }}
 {%- endblock %}
 
 {%- block extrahead %}


### PR DESCRIPTION
This ensures that if you add a custom css file through sphinx, it as inserted after our css, so you can actually override some elements of our css.

(I am experimenting with a slightly customized theme for a small package)

