### PR TITLE
Fix anchor tag padding on link

### DIFF
--- a/pydata_sphinx_theme/layout.html
+++ b/pydata_sphinx_theme/layout.html
@@ -33,7 +33,7 @@
 {% block sidebarsourcelink %}{% endblock %}
 
 {% block body_tag %}
-  <body data-spy="scroll" data-target="#bd-toc-nav" data-offset="80">
+  <body>
 {%- endblock %}
 {%- block content %}
     {% block docs_navbar %}
@@ -42,55 +42,59 @@
     </nav>
     {% endblock %}
 
-    <div class="container-xl">
-      <div class="row">
-          {% block docs_sidebar %}
-          <div class="col-12 col-md-3 bd-sidebar">
-              {%- include "docs-sidebar.html" %}
-          </div>
-          {% endblock %}
 
-          {% block docs_toc %}
-          <div class="d-none d-xl-block col-xl-2 bd-toc">
-              {% if not (meta is not none and 'notoc' in meta) %}
-                {%- include "docs-toc.html" %}
-              {% endif %}
-          </div>
-          {% endblock %}
+    <div class="content-container container-fluid" data-spy="scroll" data-target="#bd-toc-nav" data-offset="20">
+      <div class="container-xl">
+        <div class="row">
+            {% block docs_sidebar %}
+            <div class="col-12 col-md-3 bd-sidebar">
+                {%- include "docs-sidebar.html" %}
+            </div>
+            {% endblock %}
 
-          {% block docs_main %}
-          <main class="col-12 col-md-9 col-xl-7 py-md-5 pl-md-5 pr-md-4 bd-content" role="main">
-              {% block docs_body %}
-              <div>
-                {% block body %} {% endblock %}
-              </div>
-              {% endblock %}
-              {% if theme_show_prev_next %}
-              <div class='prev-next-bottom'>
-                {{ prev_next(prev, next) }}
-              </div>
-              {% endif %}
-          </main>
-          {% endblock %}
+            {% block docs_toc %}
+            <div class="d-none d-xl-block col-xl-2 bd-toc">
+                {% if not (meta is not none and 'notoc' in meta) %}
+                  {%- include "docs-toc.html" %}
+                {% endif %}
+            </div>
+            {% endblock %}
 
+            {% block docs_main %}
+            <main class="col-12 col-md-9 col-xl-7 py-md-5 pl-md-5 pr-md-4 bd-content" role="main">
+                {% block docs_body %}
+                <div>
+                  {% block body %} {% endblock %}
+                </div>
+                {% endblock %}
+                {% if theme_show_prev_next %}
+                <div class='prev-next-bottom'>
+                  {{ prev_next(prev, next) }}
+                </div>
+                {% endif %}
+            </main>
+            {% endblock %}
+
+        </div>
       </div>
+
+
+      {%- block footer %}
+      {%- include "footer.html" %}
+      {%- endblock %}
+
+      <script src="{{ pathto('_static/js/index.js', 1) }}"></script>
+      {% if theme_google_analytics_id %}
+      <!-- Google Analytics -->
+      <script>
+        window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+        ga('create', '{{ theme_google_analytics_id }}', 'auto');
+        ga('set', 'anonymizeIp', true);
+        ga('send', 'pageview');
+      </script>
+      <script async src='https://www.google-analytics.com/analytics.js'></script>
+      <!-- End Google Analytics -->
+      {% endif %}
     </div>
 
-    <script src="{{ pathto('_static/js/index.js', 1) }}"></script>
-    {% if theme_google_analytics_id %}
-    <!-- Google Analytics -->
-    <script>
-      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-      ga('create', '{{ theme_google_analytics_id }}', 'auto');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview');
-    </script>
-    <script async src='https://www.google-analytics.com/analytics.js'></script>
-    <!-- End Google Analytics -->
-    {% endif %}
-
-{%- endblock %}
-
-{%- block footer %}
-{%- include "footer.html" %}
 {%- endblock %}

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -8,7 +8,7 @@ body {
   font-weight: 400;
   line-height: 1.65;
   color: #333;
-  padding-top: 75px;
+  height: 100vh;
 }
 
 p {
@@ -48,14 +48,6 @@ a {
   font-family: 'Open Sans', sans-serif;
   font-weight: 400;
   line-height: 1.15;
-
-  &::before {
-    // offsetting html anchor titles to adjust for fixed header
-    display: block;
-    content: '';
-    height: 80px;
-    margin: -80px 0 0;
-  }
 }
 
 h1 {

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -16,7 +16,7 @@ $container-max-widths: (
 @import './base';
 @import './navbar';
 
-// Custom css, TODO: to be refactored in different partials
+
 .deprecated {
   margin-bottom: 10px;
   margin-top: 10px;
@@ -137,7 +137,7 @@ td:first-child {
   @supports (position: -webkit-sticky) or (position: sticky) {
     position: -webkit-sticky;
     position: sticky;
-    top: 5rem;
+    top: 0;
     height: calc(100vh - 5rem);
     overflow-y: auto;
   }
@@ -184,7 +184,7 @@ td:first-child {
     @supports (position: -webkit-sticky) or (position: sticky) {
       position: -webkit-sticky;
       position: sticky;
-      top: 76px;
+      top: 0px;
       z-index: 1000;
       height: calc(100vh - 4rem);
     }


### PR DESCRIPTION
This was a difficult one. I though am glad the solution remained clean and simple.

I was able to narrow down the bug defined in https://github.com/pandas-dev/pydata-sphinx-theme/issues/147 to defining `.section` with `overflow: auto;` to allow scrolling large tables and other horizontally wide elements. This breaks the height computation of the `.section` element. 

After tinkering around, and trying out different solution paths, I wrapped ;the "scrolling" content inside an extra wrapper.  This allows the padding-top on `body` to be replaced with a calculated height.