### PR TITLE
adding requirejs dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'numpydoc',
-    'recommonmark'
+    'recommonmark',
+    'jupyter_sphinx.execute'
 ]
 
 autosummary_generate = True
@@ -66,7 +67,8 @@ html_theme_options = {
     ],
     "github_url": "https://github.com/pandas-dev/pydata-sphinx-theme",
     "twitter_url": "https://twitter.com/pandas_dev",
-    "use_edit_page_button": True
+    "use_edit_page_button": True,
+    # "require_js": False  # Just for testing
 }
 
 html_context = {
@@ -75,6 +77,9 @@ html_context = {
     "github_version": "master",
     "doc_path": "docs",
 }
+
+jupyter_sphinx_require_url = ""
+
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/demo/demo.rst
+++ b/docs/demo/demo.rst
@@ -471,3 +471,21 @@ Download Links
 ==============
 
 :download:`This long long long long long long long long long long long long long long long download link should be blue, normal weight text with a leading icon, and should wrap white-spaces <static/yi_jing_01_chien.jpg>`
+
+HTML
+====
+
+The HTML below shouldn't display, but it uses RequireJS to make sure that all
+works as expected. If the widgets don't show up, RequireJS may be broken.
+
+.. jupyter-execute:: 
+
+   import plotly.io as pio
+   import plotly.express as px
+   import plotly.offline as py
+
+   pio.renderers.default = "notebook"
+
+   df = px.data.iris()
+   fig = px.scatter(df, x="sepal_width", y="sepal_length", color="species", size="sepal_length")
+   fig

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ sphinx
 numpydoc
 recommonmark
 pandas
+jupyter_sphinx
+plotly

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -101,3 +101,26 @@ Google Analytics
 
 If the ``google_analytics_id`` config option is specified (like ``UA-XXXXXXX``),
 Google Analytics' javascript is included in the html pages.
+
+
+Using with RequireJS
+====================
+
+RequireJS is a popular javascript package for managing dependencies and imports
+in a javascript codebase. Many Sphinx extensions rely on it for loading, though
+it can be tricky to get working with Bootstrap (which this theme uses).
+
+The ``pydata-sphinx-theme`` loads its own RequireJS library in order to ensure
+that `a bug isn't triggered <https://stackoverflow.com/questions/15371918/mismatched-anonymous-define-module/23467090#23467090>`_.
+**You should avoid asking extensions to load their own RequireJS**. They can still
+*use* the one that this theme loads, but they should not load their own RequireJS.
+
+If you **must** disable this theme loading RequireJS, so that you can load it manually
+or with another extension, you can do so with the following configuration: 
+
+
+.. code:: python
+
+   html_theme_options = {
+       "require_js": False
+   }

--- a/pydata_sphinx_theme/layout.html
+++ b/pydata_sphinx_theme/layout.html
@@ -23,7 +23,12 @@
     <meta name="docsearch:language" content="en">
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+    {% if theme_require_js!=False %}
+      <!-- Put RequireJS after bootstrap to avoid clashes with anonymous functions
+      see https://stackoverflow.com/questions/15371918/mismatched-anonymous-define-module/23467090#23467090 -->
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
+    {% endif %}
 {%- endblock %}
 
 {# Silence the sidebar's, relbar's #}

--- a/pydata_sphinx_theme/theme.conf
+++ b/pydata_sphinx_theme/theme.conf
@@ -13,3 +13,4 @@ google_analytics_id =
 show_prev_next = True
 search_bar_text = Search the docs ...
 search_bar_position = sidebar
+require_js = True


### PR DESCRIPTION
I was trying to get requirejs to work with Bootstrap, and I found that the only way I could do so was to load requirejs as a part of this theme, and then to disable loading it dynamically by any downstream plugins.

This was partially inspired by this issue: https://stackoverflow.com/questions/15371918/mismatched-anonymous-define-module/23467090#23467090

It seems like things behave unpredictably when `requirejs` is loaded by extensions etc, so this PR just loads it up-front and before it loads bootstrap, which seemed to be what the SO post recommended. I also added a little plotly example using `jupyter-sphinx` to test that this actually works (though feel free to recommend a more lightweight example if you can)

closes https://github.com/pandas-dev/pydata-sphinx-theme/issues/30