### PR TITLE
Automated publishing on tag creation with github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,3 +62,26 @@ jobs:
       run: |
         export PATH="$HOME/miniconda/bin:$PATH"
         sphinx-build -b html docs/ docs/_build/html -W --keep-going
+
+  publish:
+
+    name: Publish to PyPi
+    needs: [lint, tests]
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Build package
+        run: |
+          pip install wheel
+          python setup.py sdist bdist_wheel
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.1.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_KEY }}


### PR DESCRIPTION
This adds a github action to auto-publish the theme to `pypi` when a new release is created in GitHub. If this works, then the steps for cutting a new release will be:

1. Remove the `dev0` version from `__init__.py` and push to master
2. Create the release on GitHub and tag it to master
3. Bump the version in `__init__.py` and push to master

that's it!

@jorisvandenbossche I think what we'll need to do in order to test this out is to release a minor version and see if the auto-publishing works. Alternatively we can wait until we want to make a new release and just try it then.