### PR TITLE
Explicitly tell sphinx that theme is parallel safe

### DIFF
--- a/pydata_sphinx_theme/__init__.py
+++ b/pydata_sphinx_theme/__init__.py
@@ -185,3 +185,5 @@ def setup(app):
     app.set_translator("readthedocsdirhtml", BootstrapHTML5Translator, override=True)
     app.connect("html-page-context", setup_edit_url)
     app.connect("html-page-context", add_toctree_functions)
+
+    return {"parallel_read_safe": True, "parallel_write_safe": True}


### PR DESCRIPTION
Setting the parallel_read_safe sphinx metadata key would allow for faster builds using this theme.

It would also avoid the following warning when building documentation using the theme:

```
WARNING: the pydata_sphinx_theme extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explic
it
WARNING: doing serial read
```

I have tested the new settings on the documentation on my own project and I cannot see any problems.