### PR TITLE
Run and archive lighthouse report on Circle CI artifact

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -4,8 +4,20 @@ jobs:
     runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:
-      - name: GitHub Action step
-        uses: larsoner/circleci-artifacts-redirector-action@master
+      - name: Create URL for CircleCI artifact
+        id: redirect
+        uses: larsoner/circleci-artifacts-redirector-action@0.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/html/index.html
+      - name: Run Lighthouse on Site
+        id: lighthouse
+        uses: foo-software/lighthouse-check-action@v2.0.0
+        with:
+          urls: ${{ steps.redirect.outputs.url }}
+          outputDirectory: /tmp/lighthouse
+      - name: Upload Lighthouse Reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: Lighthouse Report ${{ github.run_number }}
+          path: /tmp/lighthouse


### PR DESCRIPTION
This is a smaller version of #206: as discussed over there, PRs that change the `archive` workflow are kind of hard to evaluate, so this only adds:
- upgrade `larsoner/circleci-artifacts-redirector-action` 
  - now with support for `url`
- `foo-software/lighthouse-check-action` to run the report against the `url`
  - presently only runs against `index.html`... for now
- `actions/upload` to archive the report to get an idea of the as-is state of the report

Future PRs will shave off more pieces of #206:
- use `foo-software/lighthouse-check-status-action` to validate against the top-level scores (simple 0-100 integers) to prevent regressions
- a few quick wins for performance, SEO and accessibility 