### PR TITLE
Pre-create outut folder for Lighthouse reports

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Wait Until Site is Ready
         run: |
           curl --retry 10 --retry-connrefused --retry-max-time 60 ${{ steps.redirect.outputs.url }}
+      - name: Make folder for Lighthouse reports
+        run: mkdir /tmp/lighthouse
       - name: Run Lighthouse on Site
         id: lighthouse
         uses: foo-software/lighthouse-check-action@v2.0.0


### PR DESCRIPTION
continues towards #206.

Sorry to let this slide. Turns out I missed a few steps in the copy-and-paste of the templates, and the `outputFolder` needs to already exist. This would apparently fix, for example, this run:
https://github.com/pandas-dev/pydata-sphinx-theme/runs/805676569?check_suite_focus=true

However, the timeout error still eludes me... but maybe we can start seeing some reports, some of the time!