### PR TITLE
Add logo config, and complete edit page to user guide

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -9,6 +9,16 @@ All configuration options are passed with the ``html_theme_options`` variable
 in your ``conf.py`` file. This is a dictionary with ``key: val`` pairs that
 you can configure in various ways. This page describes the options available to you.
 
+Adding Project Logo
+==============================
+
+To add a logo that's place at the left of your nav bar, put a logo file under your
+doc path's _static folder, and use the following configuration:
+
+.. code:: python
+
+   html_logo = "_static/logo.png"
+
 Configure social media buttons
 ==============================
 
@@ -69,6 +79,13 @@ your ``conf.py`` file:
        "doc_path": "<path-from-root-to-your-docs>",
    }
 
+You should also enable the edit option in your 'html_theme_options':
+
+.. code:: python
+
+   html_theme_options = {
+       "use_edit_page_button": True,
+   }
 
 Configure the search bar position
 =================================

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -9,10 +9,10 @@ All configuration options are passed with the ``html_theme_options`` variable
 in your ``conf.py`` file. This is a dictionary with ``key: val`` pairs that
 you can configure in various ways. This page describes the options available to you.
 
-Adding Project Logo
+Configure project logo
 ==============================
 
-To add a logo that's place at the left of your nav bar, put a logo file under your
+To add a logo that's placed at the left of your nav bar, put a logo file under your
 doc path's _static folder, and use the following configuration:
 
 .. code:: python


### PR DESCRIPTION
1. In the user guide, I've added a section for adding logo: 
  - this part might be redundant, as it's already in Sphinx's documentation.
  - my argument for still having it is some user may not be fluent enough in Sphinx, while still want to use pydata sphinx theme, which is a great theme. Without setting the logo, the navbar actually becomes not that great looking. By being explicit about the logo configuration in user guide, it makes it easier for user to find this setting.

2. Also, I've added additional instruction for including "edit this page". I believe this is necessary for edit this page to work:

```
html_theme_options = {
    "use_edit_page_button": True,
}
```