### PR TITLE
CI/LINT: fix python linting + pin versions 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,11 @@ repos:
         entry: bash -c "yarn build:production"
         files: ^src/*
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     -   id: black
-        language_version: python3.6
+        language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.3
     hooks:
     -   id: flake8

--- a/docs/serve.py
+++ b/docs/serve.py
@@ -22,15 +22,14 @@ SETTINGS = dict(
 
 class CacheStaticHandler(web.StaticFileHandler):
     def get_cache_time(self, *args, **kwargs):
-        """ always return a fairly long time. real deployments would have a more
-            robust solution
+        """always return a fairly long time. real deployments would have a more
+        robust solution
         """
         return int(1e10)
 
 
 def make_app():
-    """ create and return (but do not start) a tornado app
-    """
+    """create and return (but do not start) a tornado app"""
     app = web.Application(
         [(r"^/(.*)", CacheStaticHandler, dict(path=SETTINGS["static_path"]))],
         **SETTINGS
@@ -40,8 +39,7 @@ def make_app():
 
 
 def main(port, host):
-    """ start a tornado app on the desired port
-    """
+    """start a tornado app on the desired port"""
     app = make_app()
     app.listen(port, host)
     url = "http://{}:{}/".format(host, port)


### PR DESCRIPTION
I already pinned in the release commit to an older version of black to avoid a linting failure, but then here updating the version and fixing the linting issues