### PR TITLE
Add NumPy to adopters list.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ elements.
 Other sites that are using this theme:
 
 - Pandas: https://pandas.pydata.org/docs/
+- NumPy: https://numpy.org/devdocs/
 - Bokeh: https://docs.bokeh.org/en/dev/
 - JupyterHub and Binder: https://docs.mybinder.org/, http://z2jh.jupyter.org/en/latest/, https://repo2docker.readthedocs.io/en/latest/, https://jupyterhub-team-compass.readthedocs.io/en/latest/
 - Jupyter Book beta version uses an extension of this theme: https://beta.jupyterbook.org


### PR DESCRIPTION
NumPy recently adopted the pydata-sphinx-theme (numpy/numpy#17074) so I thought you might want to add it to the adopters list! Currently only the development docs are using the pydata-sphinx-theme though, so perhaps you'd prefer to wait until NumPy 1.20 at which point numpy.org/doc/stable will be using the pydata-sphinx-theme.

Either way, just thought I'd call attention to it - thanks for the great theme!