### PR TITLE
Sync adopters list of index.rst and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ generic and more easily extensible to suit the needs of the different projects.
 Sites that are using this theme:
 
 - Pandas: https://pandas.pydata.org/docs/
+- NumPy: https://numpy.org/devdocs/
 - Bokeh: https://docs.bokeh.org/en/dev/
 - JupyterHub and Binder: https://docs.mybinder.org/, http://z2jh.jupyter.org/en/latest/, https://repo2docker.readthedocs.io/en/latest/, https://jupyterhub-team-compass.readthedocs.io/en/latest/
 - Jupyter Book beta version uses an extension of this theme: https://beta.jupyterbook.org

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Other sites that are using this theme:
 - Bokeh: https://docs.bokeh.org/en/dev/
 - JupyterHub and Binder: https://docs.mybinder.org/, http://z2jh.jupyter.org/en/latest/, https://repo2docker.readthedocs.io/en/latest/, https://jupyterhub-team-compass.readthedocs.io/en/latest/
 - Jupyter Book beta version uses an extension of this theme: https://beta.jupyterbook.org
+- Fairlearn: https://fairlearn.github.io/quickstart.html
 
 
 .. toctree::


### PR DESCRIPTION
I noticed a very small detaill: adopters list in `index.rst` and `README.md` are not the same so I thought we might want to fix it.

- Added numpy to README.md
- Added fairlearn to index.rst