### PR TITLE
project name in navbar if no logo given

### DIFF
--- a/pydata_sphinx_theme/docs-navbar.html
+++ b/pydata_sphinx_theme/docs-navbar.html
@@ -1,11 +1,13 @@
 
 <div class="container-xl">
 
-    {% if logo %}
     <a class="navbar-brand" href="{{ pathto(master_doc) }}">
-      <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo">
-    </a>
+    {% if logo %}
+      <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo" />
+    {% else %}
+      <p class="title">{{ project }}</p>
     {% endif %}
+    </a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>

--- a/tests/sites/base/conf.py
+++ b/tests/sites/base/conf.py
@@ -13,6 +13,7 @@ master_doc = "index"
 # ones.
 extensions = []
 html_theme = "pydata_sphinx_theme"
+html_logo = "emptylogo.png"
 html_copy_source = True
 html_sourcelink_suffix = ""
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -80,3 +80,20 @@ def test_toc_visibility(file_regression, sphinx_build):
     # The 3rd level headers should be visible, but not the fourth-level
     assert "visible" in index_html.select(".toc-h2 ul")[0].attrs["class"]
     assert "visible" not in index_html.select(".toc-h3 ul")[0].attrs["class"]
+
+
+def test_logo_name(file_regression, sphinx_build):
+    """Test that the logo is shown by default, project title if no logo."""
+    sphinx_build.copy()
+
+    # By default logo is shown
+    sphinx_build.build()
+    index_html = sphinx_build.get("index.html")
+    assert index_html.select(".navbar-brand img")
+    assert not index_html.select(".navbar-brand")[0].text.strip()
+    sphinx_build.clean()
+
+    # Test that setting TOC level visibility works as expected
+    sphinx_build.build(["-D", "html_logo="])
+    index_html = sphinx_build.get("index.html")
+    assert "PyData Tests" in index_html.select(".navbar-brand")[0].text.strip()


### PR DESCRIPTION
This PR brings this theme in line with common convention in other Sphinx themes to include the **project name** in the navbar if no `html_logo` is given.

Current if no `html_logo` is present then the navbar sizing gets a little bit weird and there's a big whitespace to the left, so I think this is a better default behavior