### PR TITLE
Custom logo and fab option

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -29,6 +29,7 @@ following configuration:
 
    html_theme_options = {
      "github_url": "https://github.com/<your-org>/<your-repo>",
+     "gitlab_url": "https://gitlab.com/<your-org>/<your-repo>",
      "twitter_url": "https://twitter.com/<your-handle>",
    }
 
@@ -108,6 +109,18 @@ and you do not need to specify it if you wish to use the default.
        "github_url": "<your-github-url>",
    }
 
+Secondary logo in right sidebar
+====================================
+
+You can add a logo in the right sidebar below the Edit this Page button. To do so, set the following
+`html_theme_options` in your ``conf.py``:
+
+.. code:: python
+
+    html_theme_options = {
+        "secondary_logo": {"path": "_static/<image-file>", "width": "<width-of-image>"}
+    }
+ 
 Configure the search bar position
 =================================
 

--- a/pydata_sphinx_theme/docs-navbar.html
+++ b/pydata_sphinx_theme/docs-navbar.html
@@ -38,6 +38,13 @@
             </a>
           </li>
         {% endif %}
+        {% if theme_gitlab_url | length > 2 %}
+          <li class="nav-item">
+            <a class="nav-link" href="{{ theme_gitlab_url }}" target="_blank" rel="noopener">
+              <span><i class="fab fa-gitlab"></i></span>
+            </a>
+          </li>
+        {% endif %}
         {% if theme_twitter_url | length > 2 %}
           <li class="nav-item">
             <a class="nav-link" href="{{ theme_twitter_url }}" target="_blank" rel="noopener">

--- a/pydata_sphinx_theme/docs-toc.html
+++ b/pydata_sphinx_theme/docs-toc.html
@@ -22,3 +22,10 @@
 </nav>
 
 {% include "edit_this_page.html" %}
+
+{% if theme_secondary_logo %}
+<div class="tocsection secondarylogo">
+        <br/> <br/>
+        <img src="{{ pathto(theme_secondary_logo.path, 1) }} " width="{{ theme_secondary_logo.width }}" />
+</div>
+{% endif %}

--- a/pydata_sphinx_theme/theme.conf
+++ b/pydata_sphinx_theme/theme.conf
@@ -9,6 +9,7 @@ sidebar_includehidden = True
 use_edit_page_button = False
 external_links =
 github_url =
+gitlab_url =
 twitter_url =
 google_analytics_id =
 show_prev_next = True

--- a/pydata_sphinx_theme/theme.conf
+++ b/pydata_sphinx_theme/theme.conf
@@ -17,3 +17,4 @@ search_bar_text = Search the docs ...
 search_bar_position = sidebar
 navigation_with_keys = True
 show_toc_level = 1
+secondary_logo =

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -446,3 +446,7 @@ i {
     color: #130754;
   }
 }
+
+.secondarylogo {
+  padding-top: 2rem;
+}


### PR DESCRIPTION
Building on #213, which actually enables compatibility of the **Edit this page** feature with non-GitHub platforms (not just GitHub Enterprise instances), this PR enables a GitLab fab in the top-right corner.

In addition, it enables users to add a secondary logo in the right sidebar below the **Edit this page** link, which is nice for additional branding.