### PR TITLE
🐛 FIX: source_suffix throws error when it doesn't exist

### DIFF
--- a/pydata_sphinx_theme/edit_this_page.html
+++ b/pydata_sphinx_theme/edit_this_page.html
@@ -1,4 +1,4 @@
-{% if sourcename is defined and theme_use_edit_page_button==true %}
+{% if sourcename is defined and theme_use_edit_page_button==true and page_source_suffix %}
 {% set src = sourcename.split('.') %}
 <div class="tocsection editthispage">
     <a href="{{ get_edit_url() }}">


### PR DESCRIPTION
Fixes a bug which throws a `ThemeError` if the edit button is generated on a page that doesn't have a source suffix (which is the case when you're building with `singlehtml`)