### PR TITLE
DOC: fix typo - navbar_align_with_content to navbar_align)

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -226,7 +226,7 @@ page. This equals the following default configuration:
 
    html_theme_options = {
       ...
-      "navbar_align_with_content": "content"
+      "navbar_align": "content"
       ...
    }
 
@@ -237,7 +237,7 @@ configuration:
 
    html_theme_options = {
       ...
-      "navbar_align_with_content": "left"
+      "navbar_align": "left"
       ...
    }
 
@@ -247,6 +247,6 @@ If you'd like these items to snap to the right of the page, use this configurati
 
    html_theme_options = {
       ...
-      "navbar_align_with_content": "right"
+      "navbar_align": "right"
       ...
    }


### PR DESCRIPTION
@choldgraf FYA  - corrected typo in documentation:

text ```navbar_align_with_content ``` changed to: ``` navbar_align ```

_(as per comments in #263)_