### PR TITLE
Fix gitlab logo

### DIFF
--- a/pydata_sphinx_theme/docs-navbar.html
+++ b/pydata_sphinx_theme/docs-navbar.html
@@ -43,7 +43,7 @@
         {% if theme_gitlab_url | length > 2 %}
           <li class="nav-item">
             <a class="nav-link" href="{{ theme_gitlab_url }}" target="_blank" rel="noopener">
-              <span><i class="fab fa-gitlab-square"></i></span>
+              <span><i class="fab fa-gitlab"></i></span>
             </a>
           </li>
         {% endif %}


### PR DESCRIPTION
There is no square version in Font Awesome. Fixes
938aa3d5adc45ab3fc06a065951b9bafdecde68b