### PR TITLE
MAINT: Work around Sphinx deprecation

### DIFF
--- a/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -1,7 +1,9 @@
 """A custom Sphinx HTML Translator for Bootstrap layout
 """
+from distutils.version import LooseVersion
 from docutils import nodes
 
+import sphinx
 from sphinx.writers.html5 import HTML5Translator
 from sphinx.util import logging
 from sphinx.ext.autosummary import autosummary_table
@@ -25,10 +27,9 @@ class BootstrapHTML5Translator(HTML5Translator):
         # copy of sphinx source to *not* add 'docutils' and 'align-default' classes
         # but add 'table' class
 
-        # generate_targets_for_table is deprecated in 4.0, so use equivalent code:
-        for id_ in node['ids'][1:]:
-            self.body.append('<span id="%s"></span>' % id_)
-            node['ids'].remove(id_)
+        # generate_targets_for_table is deprecated in 4.0
+        if LooseVersion(sphinx.__version__) < LooseVersion("4.0"):
+            self.generate_targets_for_table(node)
 
         self._table_row_index = 0
 

--- a/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -24,7 +24,11 @@ class BootstrapHTML5Translator(HTML5Translator):
         # type: (nodes.Element) -> None
         # copy of sphinx source to *not* add 'docutils' and 'align-default' classes
         # but add 'table' class
-        self.generate_targets_for_table(node)
+
+        # generate_targets_for_table is deprecated in 4.0, so use equivalent code:
+        for id_ in node['ids'][1:]:
+            self.body.append('<span id="%s"></span>' % id_)
+            node['ids'].remove(id_)
 
         self._table_row_index = 0
 


### PR DESCRIPTION
Not 100% sure if this is a correct workaround [for this deprecation](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/writers/html5.py#L785-L789):
```
...
  File "/home/larsoner/python/pydata-sphinx-theme/pydata_sphinx_theme/bootstrap_html_translator.py", line 27, in visit_table
    self.generate_targets_for_table(node)
  File "/home/larsoner/python/sphinx/sphinx/writers/html5.py", line 780, in generate_targets_for_table
    warnings.warn('generate_targets_for_table() is deprecated',
sphinx.deprecation.RemovedInSphinx60Warning: generate_targets_for_table() is deprecated
```
But it seems to work locally at least.